### PR TITLE
(GCPVIYA-28) Increase stackname length

### DIFF
--- a/templates/iam.jinja
+++ b/templates/iam.jinja
@@ -2,10 +2,10 @@
 resources:
 
 - type: gcp-types/iam-v1:projects.serviceAccounts
-  name: {{ env['deployment'] }}-ansible-svc-account
+  name: {{ env['deployment'] }}-svcacct
   properties:
-    accountId: {{ env['deployment'] }}-ansible-svc-account   {# TODO: length can only be 6-30 #}
-    displayName: {{ env['deployment'] }}-ansible-svc-account
+    accountId: {{ env['deployment'] }}-svcacct   {# TODO: length can only be 6-30 #}
+    displayName: {{ env['deployment'] }}-svcacct
 
 
 - name: get-iam-policy
@@ -23,13 +23,13 @@ resources:
       add:
       - role: roles/storage.objectAdmin
         members:
-        - serviceAccount:$(ref.{{ env['deployment'] }}-ansible-svc-account.email)
+        - serviceAccount:$(ref.{{ env['deployment'] }}-svcacct.email)
   
 
 - type: gcp-types/iam-v1:projects.serviceAccounts.keys
   name: test-account-key
   properties:
-    parent: $(ref.{{ env['deployment'] }}-ansible-svc-account.name)
+    parent: $(ref.{{ env['deployment'] }}-svcacct.name)
     privateKeyType: TYPE_GOOGLE_CREDENTIALS_FILE
 
 {#

--- a/templates/vms.jinja
+++ b/templates/vms.jinja
@@ -9,7 +9,7 @@ resources:
     zone: {{ properties["zone"] }}
     machineType: zones/{{ properties["zone"] }}/machineTypes/g1-small
     serviceAccounts:
-    - email: $(ref.{{ env["deployment"] }}-ansible-svc-account.email)
+    - email: $(ref.{{ env["deployment"] }}-svcacct.email)
       scopes:
       - https://www.googleapis.com/auth/cloud-platform
     disks:
@@ -145,7 +145,7 @@ resources:
     machineType: zones/{{ properties["zone"] }}/machineTypes/n1-highmem-8
     hostname: services.viya.sas
     serviceAccounts:
-    - email: $(ref.{{ env["deployment"] }}-ansible-svc-account.email)
+    - email: $(ref.{{ env["deployment"] }}-svcacct.email)
       scopes:
       - https://www.googleapis.com/auth/cloud-platform    
     disks:
@@ -206,7 +206,7 @@ resources:
     machineType: zones/{{ properties["zone"] }}/machineTypes/n1-standard-2
     hostname: controller.viya.sas
     serviceAccounts:
-    - email: $(ref.{{ env["deployment"] }}-ansible-svc-account.email)
+    - email: $(ref.{{ env["deployment"] }}-svcacct.email)
       scopes:
       - https://www.googleapis.com/auth/cloud-platform    
     disks:


### PR DESCRIPTION
Changing name from <STACK>-ansible-svc-account to <STACK>-svcacct allows for a stackname of 22 characters.