### PR TITLE
(GCPVIYA-33) Convert jinja templates to python

### DIFF
--- a/templates/iam.py
+++ b/templates/iam.py
@@ -1,0 +1,52 @@
+""" Creates the IAM resources """
+
+def GenerateConfig(context):
+
+    """ Retrieve variable values from the context """
+    deployment = context.env['deployment']
+    project = context.env['project']
+
+    """ Define the IAM resources """
+    resources = [
+        {
+            'type' : "gcp-types/iam-v1:projects.serviceAccounts",
+            'name' : "%s-ansible-svc-account" % deployment,
+            'properties' : {
+                'accountId' : "%s-ansible-svc-account" % deployment,
+                'displayName' : "%s-ansible-svc-account" % deployment
+            }
+        },
+        {
+            'name' : "get-iam-policy",
+            'action' : "gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.getIamPolicy",
+            'properties' : {
+                'resource' : project
+            }
+        },
+        {
+            'name' : "patch-iam-policy",
+            'action' : "gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.setIamPolicy",
+            'properties' : {
+                'resource' : project,
+                'policy' : "$(ref.get-iam-policy)",
+                'gcpIamPolicyPatch' : {
+                    'add' : [{
+                        'role' : "roles/storage.objectAdmin",
+                        'members' : [
+                            "serviceAccount:$(ref.%s-ansible-svc-account.email)" % deployment
+                        ]
+                    }]
+                }
+            }
+        },
+        {
+            'name' : "test-account-key",
+            'type' : "gcp-types/iam-v1:projects.serviceAccounts.keys",
+            'properties' : {
+                'parent' : "$(ref.%s-ansible-svc-account.name)" % deployment,
+                'privateKeyType' : "TYPE_GOOGLE_CREDENTIALS_FILE"
+            }
+        }
+    ]
+
+    return { 'resources' : resources }

--- a/templates/loadbalancer.py
+++ b/templates/loadbalancer.py
@@ -1,0 +1,108 @@
+"""Load balancer resources"""
+
+def GenerateConfig(context):
+
+    """ Retrieve varable values from the context """
+    deployment = context.env['deployment']
+    project = context.env['project']
+    region = context.properties['region']
+    zone = context.properties['zone']
+
+    """ Define the Load Balancer resources """
+    resources = [
+        {
+            'name' : "%s-loadbalancer-ip" % deployment,
+            'type' : "gcp-types/compute-v1:addresses",
+            'properties' : {
+                'networkTier' : "STANDARD",
+                'region' : region
+            }
+        },
+        {
+            'name' : "%s-instance-group" % deployment,
+            'type' : "gcp-types/compute-v1:instanceGroups",
+            'properties' : {
+                'managed' : "no",
+                'zone' : zone,
+                'network' : "$(ref.%s-vpc.selfLink)" % deployment,
+                'namedPorts' : [
+                    { 'name' : "http", 'port' : 80 },
+                    { 'name' : "https", 'port' : 443}
+                ]
+            }
+        },
+        {
+            'name' : "add-to-instance-group",
+            'action' : "gcp-types/compute-v1:compute.instanceGroups.addInstances",
+            'properties' : {
+                'project' : project,
+                'zone' : zone,
+                'instanceGroup' : "%s-instance-group" % deployment,
+                'instances' : [
+                    {
+                        'instance' : "$(ref.%s-services.selfLink)" % deployment
+                    }
+                ]
+            }
+        },
+        {
+            'name' : "%s-http-healthcheck" % deployment,
+            'type' : "gcp-types/compute-v1:httpHealthChecks",
+            'properties' : {
+                'requestPath' : "/SASLogon/login",
+                'port' : 80
+            }
+        },
+        {
+            'name' : "%s-https-healthcheck" % deployment,
+            'type' : "gcp-types/compute-v1:httpsHealthChecks",
+            'properties' : {
+                'requestPath' : "/SASLogon/login",
+                'port' : 443
+            }
+        },
+        {
+            'name' : "%s-backend" % deployment,
+            'type' : "gcp-types/compute-v1:backendServices",
+            'properties': {
+                'port' : 80,
+                'portName' : "http",
+                'protcol' : "HTTP",
+                'backends' : [
+                    { 'group' : "$(ref.%s-instance-group.selfLink)" % deployment }
+                ],
+                'healthChecks' : [
+                    "$(ref.%s-http-healthcheck.selfLink)" % deployment
+                ]
+            }
+        },
+        {
+            'name' : "%s-loadbalancer" % deployment,
+            'type' : "gcp-types/compute-v1:urlMaps",
+            'properties' : {
+                'defaultService' : "$(ref.%s-backend.selfLink)" % deployment
+            }
+        },
+        {
+            'name' : "%s-loadbalancer-target-proxy" % deployment,
+            'type' : "gcp-types/compute-v1:targetHttpProxies",
+            'properties' : {
+                'protocol' : "HTTP",
+                'urlMap' : "$(ref.%s-loadbalancer.selfLink)" % deployment
+            }
+        },
+        {
+            'name' : "%s-forwarding-rules" % deployment,
+            'type' : "gcp-types/compute-v1:forwardingRules",
+            'properties' : {
+                'IPAddress' : "$(ref.%s-loadbalancer-ip.selfLink)" % deployment,
+                'IPProtocol' : "TCP",
+                'networkTier' : "STANDARD",
+                'portRange' : 80,
+                'region' : region,
+                'target' : "$(ref.%s-loadbalancer-target-proxy.selfLink)" % deployment
+            }
+        }
+    ]
+
+    return { 'resources' : resources }

--- a/templates/networks.py
+++ b/templates/networks.py
@@ -1,0 +1,121 @@
+""" Creates the network resources """
+
+def GenerateConfig(context) :
+
+    """ Retrieve the variable values from the context """
+    deployment = context.env['deployment']
+    region = context.properties['region']
+    admin_ingress_location = context.properties['AdminIngressLocation']
+
+    """ Define the network resources """
+    resources = [
+        {
+            'name' : "%s-vpc" % deployment,
+            'type' : "gcp-types/compute-v1:networks",
+            'properties' : {
+                'autoCreateSubnetworks' : False
+            }
+        },
+        {
+            'name' : "%s-public-subnet" % deployment,
+            'type' : "gcp-types/compute-v1:subnetworks",
+            'properties' : {
+                'region' : region,
+                'ipCidrRange' : "10.0.128.0/20",
+                'network' : "$(ref.%s-vpc.selfLink)" % deployment
+            }
+        },
+        {
+            'name' : "%s-private-subnet" % deployment,
+            'type' : "gcp-types/compute-v1:subnetworks",
+            'properties' : {
+                'region' : region,
+                'ipCidrRange' : "10.20.128.0/20",
+                'network' : "$(ref.%s-vpc.selfLink)" % deployment
+            }
+        },
+        {
+            'name' : "%s-nat" % deployment,
+            'type' : "gcp-types/compute-v1:routers",
+            'properties' : {
+                'region' : region,
+                'network' : "$(ref.%s-vpc.selfLink)" % deployment,
+                'nats' : [{
+                    'name' : "%s-nat" % deployment,
+                    'subnetworks' : [{
+                        'name' : "$(ref.%s-private-subnet.selfLink)" % deployment,
+                        'sourceIpRangesToNat' : [
+                            "ALL_IP_RANGES"
+                        ]
+                    }],
+                    'natIpAllocateOption' : "AUTO_ONLY",
+                    'sourceSubnetworkIpRangesToNat' : "LIST_OF_SUBNETWORKS"
+                }]
+            }
+        },
+        {
+            'name' : "%s-allow-ansible-external-access" % deployment,
+            'type' : "gcp-types/compute-v1:firewalls",
+            'properties' : {
+                'network' : "$(ref.%s-vpc.selfLink)" % deployment,
+                'sourceRanges' : [
+                    admin_ingress_location
+                ],
+                'allowed' : [{
+                    'IPProtocol' : "tcp",
+                    'ports' : [
+                        22
+                    ]
+                }]
+            }
+        },
+        {
+            'name' : "%s-allow-viya-ssh-from-ansible" % deployment,
+            'type' : "gcp-types/compute-v1:firewalls",
+            'properties' : {
+                'network' : "$(ref.%s-vpc.selfLink)" % deployment,
+                'sourceTags' : [
+                    "sas-viya-ansible-controller"
+                ],
+                'allowed' : [{
+                    'IPProtocol' : "tcp",
+                    'ports' : [
+                        22
+                    ]
+                }]
+            }
+        },
+        {
+            'name' : "%s-allow-viya-to-viya" % deployment,
+            'type' : "gcp-types/compute-v1:firewalls",
+            'properties' : {
+                'network' : "$(ref.%s-vpc.selfLink)" % deployment,
+                'sourceTags' : [
+                    "sas-viya-vm"
+                ],
+                'allowed' : [{
+                    'IPProtocol' : "tcp"
+                }]
+            }
+        },
+        {
+            'name' : "%s-vpc-allow-http" % deployment,
+            'type' : "gcp-types/compute-v1:firewalls",
+            'properties' : {
+                'description' : "Incoming http and https allowed.",
+                'network' : "$(ref.%s-vpc.selfLink)" % deployment,
+                'targetTags' : [
+                    "sas-viya-vm"
+                ],
+                'allowed' : [{
+                    'IPProtocol' : "tcp",
+                    'ports' : [
+                        80,
+                        443
+                    ]
+                }]
+            }
+        }
+    ]
+
+    return { 'resources' : resources }

--- a/templates/sas-viya-config.yaml
+++ b/templates/sas-viya-config.yaml
@@ -13,11 +13,11 @@ resources:
     COMMON_CODE_TAG: GCPVIYA-1.1
     
     ### Replace these variables with customer provided values
-    zone: ZONE
-    ssh-key: PUBLIC_SSH_KEY
+    zone: us-east1-b
+    ssh-key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmj4OjEV/fQQRB4w1X/CbJz55FVHWtWJJ8mrOTM9xCEevza4xhB0YXKn64IZtVLvTK+pN+p2LWlIN4BIEjG6gB1q3Kr2xoZQ5kFlR2bZwirYDxYwM0UyQWBodHVDjJHZZREKj/c9zM+KMePpPAb5P6/KQE13Y74ZN4FkQXUSX5GQM6hb778TuSaIKb4k7cSQ1MJoOcF3ED+QVSraqip8d4ZDpJV9r1/UVwTvKRAP9WH8ByVeHW15RVJASdU+vLX9zODksxCrGNMATqOow8/n8p9auoYPuRfZn7T5DZATx3q9Rh4yOD/MRNnQ+8cVRGw9fDDsQoic59dOY204Cro2wj a3scas
     # Used by openldapsetup playbook
-    OLCROOTPW: ROOT_PASSWORD
-    OLCUSERPW: USER_PASSWORD
+    OLCROOTPW: go4thsas
+    OLCUSERPW: go4thsas
     # Google storage bucket location and file name of SAS License file
-    DEPLOYMENT_DATA_LOCATION: gs://BUCKET_PATH/LICENSE_FILENAME.ZIP
-    
+    DEPLOYMENT_DATA_LOCATION: gs://mercury-deployment-data/viya3.4/SAS_Viya_deployment_data_VDMMLDP_all_4Core.zip
+   

--- a/templates/sas-viya-template.jinja
+++ b/templates/sas-viya-template.jinja
@@ -1,13 +1,16 @@
 resources:
 
+- name: iam
+  type: iam.py
+
 - name: networks
-  type: networks.jinja
+  type: networks.py
   properties:
     region: {{ properties["zone"][:-2] }}
     AdminIngressLocation: {{ properties["AdminIngressLocation"] }}
 
 - name: vms
-  type: vms.jinja
+  type: vms.py
   properties:
      zone: {{ properties["zone"] }}
      ssh-key: {{ properties["ssh-key"] }}
@@ -16,13 +19,9 @@ resources:
      OLCUSERPW: {{ properties["OLCUSERPW"] }}
      VIYA_VERSION: {{ properties["VIYA_VERSION"] }}
      DEPLOYMENT_DATA_LOCATION: {{ properties["DEPLOYMENT_DATA_LOCATION"] }}
-          
-- name: iam
-  type: iam.jinja
 
 - name: loadbalancer
-  type: loadbalancer.jinja
+  type: loadbalancer.py
   properties:
      zone: {{ properties["zone"] }}
      region: {{ properties["zone"][:-2] }}
-     

--- a/templates/sas-viya-template.jinja.schema
+++ b/templates/sas-viya-template.jinja.schema
@@ -4,16 +4,16 @@ info:
   description: GCP Deployment Manager template for deploying SAS Viya software
 
 imports:
-- path: networks.jinja
-- path: vms.jinja
-- path: iam.jinja
-- path: loadbalancer.jinja
+- path: iam.py
+- path: networks.py
+- path: vms.py
+- path: loadbalancer.py
 
 required:
 - zone
 - ssh-key
 - AdminIngressLocation
- 
+
 
 properties:
   zone:
@@ -22,12 +22,11 @@ properties:
 
   ssh-key:
     type: string
-    description: Public SSH key for ansible controller  
-    
+    description: Public SSH key for ansible controller
+
   AdminIngressLocation:
     type: string
     descriptionn: Allow inbound SSH traffic to the Ansible Controller from this CIDR block (IP address range). Must be a valid IP CIDR range of the form x.x.x.x/x.
     MinLength: '9'
     MaxLength: '18'
     pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    

--- a/templates/vms.py
+++ b/templates/vms.py
@@ -1,0 +1,330 @@
+"""Creates three VMs: anisble controller, viya services and cas controller"""
+
+""" Startup script for Ansible Controller """
+ansible_startup_script = '''#!/bin/bash
+# The VM needs a few seconds to come up before executing the startup scripts
+sleep 10
+###################################
+# Setting up environment
+###################################
+export COMMON_CODE_TAG="%s"
+export OLCROOTPW="%s"
+export OLCUSERPW="%s"
+export VIYA_VERSION="%s"
+export DEPLOYMENT_DATA_LOCATION="%s"
+export IAAS=gcp
+export INSTALL_DIR=/sas/install
+export LOG_DIR=/var/log/sas/install
+/bin/su sasinstall -c "export > /home/sasinstall/SAS_VIYA_DEPLOYMENT_ENVIRONMENT"
+###################################
+# Installing dependencies
+###################################
+yum install -y java-1.8.0-openjdk
+yum install -y epel-release
+yum install -y python-pip
+yum install -y git
+# Getting quick start scripts from Github  # TODO: Remove '-b develop' before push to master
+git clone https://github.com/sassoftware/quickstart-sas-viya-gcp $INSTALL_DIR -b develop
+# Clean up GitHub identifier files
+pushd $INSTALL_DIR
+rm -rf .git*
+popd
+# Getting specific release of quick start common code from Github
+git clone https://github.com/sassoftware/quickstart-sas-viya-common $INSTALL_DIR/common
+pushd $INSTALL_DIR/common
+git checkout tags/$COMMON_CODE_TAG -b $COMMON_CODE_TAG
+# Clean up GitHub identifier files
+rm -rf .git*
+popd
+# Updating ownership so that sasinstall user can read/write
+chown -R sasinstall:sasinstall $INSTALL_DIR
+# Bootstrapping ansible controller machine
+/bin/su sasinstall -c "$INSTALL_DIR/common/scripts/ansiblecontroller_prereqs.sh"
+export ANSIBLE_CONFIG=$INSTALL_DIR/common/ansible/playbooks/ansible.cfg
+###################################
+# Ansible playbook does additional steps needed before installing SAS, including
+# - host routing
+# - volume attachments
+# - setting up directories and users
+###################################
+export ANSIBLE_LOG_PATH=$LOG_DIR/prepare_nodes.log
+/bin/su sasinstall -c "ansible-playbook -v $INSTALL_DIR/common/ansible/playbooks/prepare_nodes.yml \
+   -e SAS_INSTALL_DISK=/dev/disk/by-id/google-sashome \
+   -e USERLIB_DISK=/dev/disk/by-id/google-userlib \
+   -e CASCACHE_DISK=/dev/disk/by-id/google-cascache"
+###################################
+# Ansible playbook sets up an OpenLDAP server that can be used as initial identity provider for SAS Viya.
+###################################
+export ANSIBLE_LOG_PATH=$LOG_DIR/openldapsetup.log
+/bin/su sasinstall -c "ansible-playbook -v $INSTALL_DIR/common/ansible/playbooks/openldapsetup.yml \
+   -e OLCROOTPW=$(echo -n "$OLCROOTPW" | base64) \
+   -e OLCUSERPW=$(echo -n "$OLCUSERPW" | base64)"
+###################################
+# Ansible playbook does additional steps needed before installing SAS,  including
+# - download sas-orchestration
+# - set up access to deployment mirror (optional)
+# - build playbook from SOE file
+# - modify inventory.ini and vars.yml
+###################################
+export ANSIBLE_LOG_PATH=$LOG_DIR/prepare_deployment.log
+/bin/su sasinstall -c "ansible-playbook -v $INSTALL_DIR/common/ansible/playbooks/prepare_deployment.yml \
+   -e DEPLOYMENT_DATA_LOCATION=$DEPLOYMENT_DATA_LOCATION \
+   -e ADMINPASS=$(echo "$OLCROOTPW" | base64) \
+   -e VIYA_VERSION=$VIYA_VERSION"
+###################################
+# Run VIRK
+# The VIRK pre-install playbook covers most of the Viya Deployment Guide prereqs in one fell swoop.
+###################################
+export ANSIBLE_LOG_PATH=$LOG_DIR/virk.log
+export ANSIBLE_INVENTORY=$INSTALL_DIR/ansible/sas_viya_playbook/inventory.ini
+/bin/su sasinstall -c "ansible-playbook -v $INSTALL_DIR/ansible/sas_viya_playbook/virk/playbooks/pre-install-playbook/viya_pre_install_playbook.yml \
+  -e "use_pause=false" \
+  --skip-tags skipmemfail,skipcoresfail,skipstoragefail,skipnicssfail,bandwidth"
+##################################
+# Install Viya
+##################################
+export ANSIBLE_LOG_PATH=$LOG_DIR/viya_deployment.log
+export ANSIBLE_CONFIG=$INSTALL_DIR/ansible/sas_viya_playbook
+pushd /sas/install/ansible/sas_viya_playbook
+/bin/su sasinstall -c "ansible-playbook -v site.yml"
+##################################
+# Post Deployment Steps
+##################################
+export ANSIBLE_LOG_PATH=$LOG_DIR/post_deployment.log
+export ANSIBLE_CONFIG=$INSTALL_DIR/common/ansible/playbooks/ansible.cfg
+/bin/su sasinstall -c "ansible-playbook -v $INSTALL_DIR/common/ansible/playbooks/post_deployment.yml"
+##################################
+# Final system update
+##################################
+yum -y update
+/bin/su sasinstall -c "echo 'Check /var/log/sas/install for deployment logs.' > /home/sasinstall/SAS_VIYA_DEPLOYMENT_FINISHED"
+'''
+
+""" Startup script for viya services """
+services_startup_script = '''#! /bin/bash
+# Setting up environment
+export NFS_SERVER=%s-ansible-controller
+export HOST=`hostname`
+# Installing dependencies
+yum -y install git
+# Getting quick start scripts
+git clone https://github.com/sassoftware/quickstart-sas-viya-common /tmp/common
+# Bootstrapping all SAS VM
+/bin/su sasinstall -c '/tmp/common/scripts/sasnodes_prereqs.sh'
+# VIRK requires GID 1001 to be free
+groupmod -g 2001 sasinstall
+# Final system update
+yum -y update
+'''
+
+""" Startup script for cas controller """
+controller_startup_script = '''#!/bin/bash
+# Setting up environment
+export NFS_SERVER=%s-ansible-controller
+export HOST=`hostname`
+# Installing dependencies
+yum -y install git
+# Getting quick start scripts
+git clone https://github.com/sassoftware/quickstart-sas-viya-common /tmp/common
+# Bootstrapping all SAS VM
+/bin/su sasinstall -c '/tmp/common/scripts/sasnodes_prereqs.sh'
+# VIRK requires GID 1001 to be free
+groupmod -g 2001 sasinstall
+# Final system update
+yum -y update
+'''
+
+def GenerateConfig(context):
+
+    """ Retrieve variable values from the context """
+    common_code_tag = context.properties['COMMON_CODE_TAG']
+    olc_root_pw = context.properties['OLCROOTPW']
+    olc_user_pw = context.properties['OLCUSERPW']
+    viya_version = context.properties['VIYA_VERSION'].replace('\\', '')
+    deployment_data_location = context.properties['DEPLOYMENT_DATA_LOCATION']
+    deployment = context.env['deployment']
+    zone = context.properties['zone']
+    ssh_key = context.properties['ssh-key']
+
+    """ Define the resources for the VMs """
+    resources = [
+        {
+            'name' : "%s-ansible-controller" % deployment,
+            'type' : 'gcp-types/compute-v1:instances',
+            'properties' : {
+                'zone' : zone,
+                'machineType' : "zones/%s/machineTypes/g1-small" % zone,
+                'serviceAccounts' : [{
+                    'email' : "$(ref.%s-ansible-svc-account.email)" % deployment,
+                    'scopes' : [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                    ]
+                }],
+                'disks' : [{
+                    'deviceName' : 'boot',
+                    'type' : 'PERSISTENT',
+                    'boot' : True,
+                    'autoDelete' : True,
+                    'initializeParams': {
+                        'sourceImage' : "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7",
+                        'diskSizeGb' : 10
+                    }
+                }],
+                'networkInterfaces' : [{
+                    'subnetwork' : "$(ref.%s-public-subnet.selfLink)" % deployment,
+                    'accessConfigs' : [{
+                        'name' : 'External NAT',
+                        'type' : 'ONE_TO_ONE_NAT'
+                    }],
+                }],
+                'tags' : {
+                    'items' : [
+                        'sas-viya-ansible-controller'
+                    ]
+                },
+                'metadata' : {
+                    'items' : [
+                        { 'key' : 'ssh-keys', 'value' : "sasinstall:%s" % ssh_key },
+                        { 'key' : 'block-project-ssh-keys', 'value' : "true" },
+                        { 'key' : 'startup-script', 'value' : ansible_startup_script % (common_code_tag, olc_root_pw, olc_user_pw, viya_version, deployment_data_location) }
+                    ]
+                }
+            }
+        },
+        {
+            'name' : "%s-services" % deployment,
+            'type' : "gcp-types/compute-v1:instances",
+            'properties': {
+                'zone' : zone,
+                'machineType' : "zones/%s/machineTypes/n1-highmem-8" % zone,
+                'hostname' : "services.viya.sas",
+                'serviceAccounts' : [{
+                    'email' : "$(ref.%s-ansible-svc-account.email)" % deployment,
+                    'scopes' : [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                    ]
+                }],
+                'disks' : [
+                    {
+                        'deviceName' : 'boot',
+                        'type': "PERSISTENT",
+                        'boot' : True,
+                        'autoDelete' : True,
+                        'initializeParams': {
+                            'sourceImage' : "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7",
+                            'diskSizeGb' : 25
+                        }
+                    },
+                    {
+                        'deviceName' : 'sashome',
+                        'type' : "PERSISTENT",
+                        'boot' : False,
+                        'autoDelete' : True,
+                        'initializeParams' : {
+                            'diskName' : "%s-sashome-services" % deployment,
+                            'diskSizeGb' : 100,
+                            'description' : "SAS_INSTALL_DISK"
+                        }
+                    }
+                ],
+                'networkInterfaces' : [{
+                    'subnetwork' : "$(ref.%s-private-subnet.selfLink)" % deployment
+                }],
+                'metadata' : {
+                    'items' : [
+                        { 'key' : 'ssh-keys', 'value' : "sasinstall:%s" % ssh_key },
+                        { 'key' : 'block-project-ssh-keys', 'value' : "true" },
+                        { 'key' : 'startup-script', 'value' : services_startup_script % deployment }
+                    ]
+                },
+                'tags' : {
+                    'items' : [
+                        'sas-viya-vm'
+                    ]
+                }
+            }
+        },
+        {
+            'name' : "%s-controller" % deployment,
+            'type' : "gcp-types/compute-v1:instances",
+            'properties': {
+                'zone' : zone,
+                'machineType' : "zones/%s/machineTypes/n1-standard-2" % zone,
+                'hostname' : "controller.viya.sas",
+                'serviceAccounts' : [{
+                    'email' : "$(ref.%s-ansible-svc-account.email)" % deployment,
+                    'scopes' : [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                    ]
+                }],
+                'disks' : [
+                    {
+                        'deviceName' : "boot",
+                        'type' : "PERSISTENT",
+                        'boot' : True,
+                        'autoDelete' : True,
+                        'initializeParams' : {
+                            'sourceImage' : "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7",
+                            'diskSizeGb' : 10
+                        }
+                    },
+                    {
+                        'deviceName' : "sashome",
+                        'type' : "PERSISTENT",
+                        'boot' : False,
+                        'autoDelete' : True,
+                        'initializeParams' : {
+                            'diskName' : "%s-sashome-controller" % deployment,
+                            'diskSizeGb' : 50,
+                            'description' : "SAS_INSTALL_DISK"
+                        }
+                    },
+                    {
+                        'deviceName' : "userlib",
+                        'type' : "PERSISTENT",
+                        'boot' : False,
+                        'autoDelete' : True,
+                        'kind' : "compute",
+                        'mode' : "READ_WRITE",
+                        'initializeParams' : {
+                            'diskName' : "%s-userlib" % deployment,
+                            'diskType' : "projects/ace-dev/zones/%s/diskTypes/pd-standard" % zone,
+                            'diskSizeGb' : 50,
+                            'description' : "USERLIB_DISK"
+                        }
+                    },
+                    {
+                        'deviceName' : "cascache",
+                        'type' : "PERSISTENT",
+                        'boot' : False,
+                        'autoDelete' : True,
+                        'kind' : "compute",
+                        'mode' : "READ_WRITE",
+                        'initializeParams' : {
+                            'diskName' : "%s-cascache" % deployment,
+                            'diskType' : "projects/ace-dev/zones/%s/diskTypes/pd-standard" % zone,
+                            'diskSizeGb' : 50,
+                            'description' : "CASCACHE_DISK"
+                        }
+                    }
+                ],
+                'networkInterfaces' : [{
+                    'subnetwork' : "$(ref.%s-private-subnet.selfLink)" % deployment
+                }],
+                'metadata' : {
+                    'items' : [
+                        { 'key' : "ssh-keys", 'value' : "sasinstall:%s" % ssh_key },
+                        { 'key' : "block-project-ssh-keys", 'value' : "true" },
+                        { 'key' : "startup-script", 'value': controller_startup_script % deployment }
+                    ]
+                },
+                'tags' : {
+                    'items' : [
+                        "sas-viya-vm"
+                    ]
+                }
+            }
+        }
+    ]
+
+    return { 'resources' : resources }


### PR DESCRIPTION
This commit migrates the deployment to use python templates instead of jinja
templates. This will allow us more control over the resource definitions.