### PR TITLE
(GCPVIYA-19) Add SASDrive and SASStudio output values

### DIFF
--- a/templates/loadbalancer.py
+++ b/templates/loadbalancer.py
@@ -99,4 +99,17 @@ def GenerateConfig(context):
         }
     ]
 
-    return { 'resources' : resources }
+
+    outputs = [
+        {
+            'name' : 'SASDrive',
+            'value' : "https://$(ref.%s-loadbalancer-ip.address)/SASDrive" % deployment
+        },
+        {
+            'name' : 'SASStudio',
+            'value' : "https://$(ref.%s-loadbalancer-ip.address)/SASStudioV" % deployment
+        }
+    ]
+    
+
+    return { 'resources' : resources, 'outputs' : outputs }


### PR DESCRIPTION
This commit adds two output values to the loadbalancer:

SASDrive: the url for the SASDrive, i.e. https://<server ip>/SASDrive

SASStudio: the url for the SASStudio, i.e. https://<server-ip>/SASStudioV

These urls can be used in a browser to access SAS/Viya